### PR TITLE
Add compatibility with macOS

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ clap = { version = "3.1.6", features = ["derive"] }
 
 [build-dependencies]
 bindgen = "*"
+pkg-config = "0.3.25"
 
 [features]
 auto = ["filesystem-macro"]

--- a/build.rs
+++ b/build.rs
@@ -38,9 +38,20 @@ fn main() {
         // for versioning issues. In theory these operations
         // shouldn't show up on the struct at all, but whatever
         // I'm not mad or anything like that's totally fine I'm fine.
+        let mut blacklisted = vec!["getdir, utime"];
+
+        // macOS makes me question my reality.
+        #[cfg(target_os = "macos")]
+        {
+            blacklisted.extend(vec!["reserved00, reserved01"]);
+        }
+
         bindings_raw.insert_str(
             operations_loc,
-            "#[filesystem_macro::fuse_operations[getdir, utime]]\n",
+            &format!(
+                "#[filesystem_macro::fuse_operations[{}]]",
+                blacklisted.join(", ")
+            ),
         );
 
         fs::write(out, bindings_raw).unwrap();

--- a/build.rs
+++ b/build.rs
@@ -43,7 +43,7 @@ fn main() {
         // macOS makes me question my reality.
         #[cfg(target_os = "macos")]
         {
-            blacklisted.extend(vec!["reserved00, reserved01"]);
+            blacklisted.extend(["reserved00, reserved01"]);
         }
 
         bindings_raw.insert_str(

--- a/build.rs
+++ b/build.rs
@@ -5,7 +5,14 @@ fn main() {
     // and (*fuse_get_conext()).private_data gets mangled
     println!("cargo:rustc-link-lib=fuse");
 
+    let library = pkg_config::probe_library("fuse").expect("pkg-config failed to find fuse");
     let bindings = bindgen::Builder::default()
+        .clang_args(
+            library
+                .include_paths
+                .iter()
+                .map(|path| format!("-I{}", path.to_string_lossy())),
+        )
         .header("wrapper.h")
         .derive_default(true)
         .generate()

--- a/examples/passthrough.rs
+++ b/examples/passthrough.rs
@@ -24,7 +24,7 @@ impl Passthrough {
 
 impl UnthreadedFileSystem for Passthrough {
     fn chmod(&mut self, path: &str, mode: mode_t) -> Result<i32> {
-        set_permissions(self.source(path), Permissions::from_mode(mode)).map(|_| 0)
+        set_permissions(self.source(path), Permissions::from_mode(mode.into())).map(|_| 0)
     }
 
     fn create(
@@ -41,7 +41,7 @@ impl UnthreadedFileSystem for Passthrough {
         options
             .create(true)
             .append(true)
-            .mode(mode)
+            .mode(mode.into())
             .open(self.source(path))
             .map(|_| 0)
     }
@@ -65,7 +65,7 @@ impl UnthreadedFileSystem for Passthrough {
     fn mkdir(&mut self, path: &str, mode: mode_t) -> Result<i32> {
         let path = self.source(path);
         create_dir(&path)?;
-        set_permissions(path, Permissions::from_mode(mode)).map(|_| 0)
+        set_permissions(path, Permissions::from_mode(mode.into())).map(|_| 0)
     }
 
     fn mknod(&mut self, path: &str, mode: mode_t, dev: dev_t) -> Result<i32> {

--- a/wrapper.h
+++ b/wrapper.h
@@ -1,2 +1,7 @@
+#ifdef __APPLE__
+#define FUSE_USE_VERSION 26
+#endif
+
 #define _FILE_OFFSET_BITS  64
+
 #include <fuse.h>


### PR DESCRIPTION
Use `pkg-config` to locate include paths.
Also add certain macOS-specific reserved functions to blacklist.